### PR TITLE
remove watning like "EventEmitter.removeListener('change', ...): Meth…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,9 @@ const useDimensionsListener = () => {
       setScreenDimension(screen);
     }
 
-    Dimensions.addEventListener("change", handleDimensionChange);
+    let handleDimensionChangeLinstener = Dimensions.addEventListener("change", handleDimensionChange);
     return () => {
-      Dimensions.removeEventListener("change", handleDimensionChange);
+      handleDimensionChangeLinstener.remove();
     };
   }, []);
 


### PR DESCRIPTION
 Since EventEmitter.removeListener('change', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.

from react native 0.66